### PR TITLE
82 annotation literals

### DIFF
--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.interceptor.InterceptorBinding;
 
 /**
@@ -56,4 +57,17 @@ import javax.interceptor.InterceptorBinding;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface AutoApplySession {
+    
+    /**
+     * A default literal for the {@link AutoApplySession} annotation.
+     *
+     * @since 1.1
+     */
+    public final static class Literal extends AnnotationLiteral<AutoApplySession> implements AutoApplySession {
+        
+        private static final long serialVersionUID = 1L;
+
+        public static final Literal INSTANCE = new Literal();
+
+    }
 }

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,7 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package javax.security.enterprise.authentication.mechanism.http;
 
 import static java.lang.annotation.ElementType.TYPE;
@@ -30,17 +30,17 @@ import javax.interceptor.InterceptorBinding;
  * The AutoApplySession annotation provides an application the ability to declaratively designate
  * that an authentication mechanism uses the <code>javax.servlet.http.registerSession</code>
  * and auto applies this for every request.
- * 
+ *
  * <p>
  * See the JASPIC 1.1 specification section 3.8.4 for further details on <code>javax.servlet.http.registerSession</code>.
- * 
+ *
  * <p>
  * This support is provided via an implementation of an interceptor spec interceptor that conducts the
  * necessary logic.
- * 
+ *
  * <p>
  * Example:
- * 
+ *
  * <pre>
  * <code>
  *     {@literal @}RequestScoped
@@ -57,14 +57,15 @@ import javax.interceptor.InterceptorBinding;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface AutoApplySession {
-    
+
     /**
      * A default literal for the {@link AutoApplySession} annotation.
      *
      * @since 1.1
      */
+    @SuppressWarnings("all")
     public final static class Literal extends AnnotationLiteral<AutoApplySession> implements AutoApplySession {
-        
+
         private static final long serialVersionUID = 1L;
 
         public static final Literal INSTANCE = new Literal();

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/LoginToContinue.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/LoginToContinue.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,25 +24,26 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
 
 /**
- * The <code>LoginToContinue</code> annotation provides an application the ability to declaratively 
+ * The <code>LoginToContinue</code> annotation provides an application the ability to declaratively
  * add login to continue functionality to an authentication mechanism.
- * 
+ *
  * <p>
  * When the <code>LoginToContinue</code> annotation is used on a custom authentication mechanism, EL
- * expressions in attributes of type <code>String</code> are evaluated for every request requiring 
+ * expressions in attributes of type <code>String</code> are evaluated for every request requiring
  * authentication. Both immediate and deferred syntax is supported, but effectively the semantics
  * are always deferred.
- * 
+ *
  * <p>
- * When the <code>LoginToContinue</code> annotation is used as attribute in either the 
+ * When the <code>LoginToContinue</code> annotation is used as attribute in either the
  * {@link FormAuthenticationMechanismDefinition} or {@link CustomFormAuthenticationMechanismDefinition},
  * expressions using immediate syntax are evaluated only once when the {@link HttpAuthenticationMechanism}
  * bean is created. Since these beans are application scoped, this means only once per application.
- * Expressions using deferred syntax are evaluated as described above when the <code>LoginToContinue</code> annotation 
+ * Expressions using deferred syntax are evaluated as described above when the <code>LoginToContinue</code> annotation
  * is used on a custom authentication mechanism.
  *
  */
@@ -50,43 +52,128 @@ import javax.interceptor.InterceptorBinding;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface LoginToContinue {
-    
+
+    /**
+     * A default literal type for the {@link LoginToContinue} annotation.
+     *
+     * @since 1.1
+     */
+    @SuppressWarnings("all")
+    public final static class Literal extends AnnotationLiteral<LoginToContinue> implements LoginToContinue {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String loginPage;
+        private final boolean useForwardToLogin;
+        private final String useForwardToLoginExpression;
+        private final String errorPage;
+
+        public static LiteralBuilder of() {
+            return new LiteralBuilder();
+        }
+
+        public static class LiteralBuilder {
+
+            private String loginPage = "/login";
+            private boolean useForwardToLogin = true;
+            private String useForwardToLoginExpression;
+            private String errorPage = "/login-error";
+
+            public LiteralBuilder loginPage (String loginPage) {
+                this.loginPage = loginPage;
+                return this;
+            }
+
+            public LiteralBuilder useForwardToLogin (boolean useForwardToLogin) {
+                this.useForwardToLogin = useForwardToLogin;
+                return this;
+            }
+
+            public LiteralBuilder useForwardToLoginExpression (String useForwardToLoginExpression) {
+                this.useForwardToLoginExpression = useForwardToLoginExpression;
+                return this;
+            }
+
+            public LiteralBuilder errorPage (String errorPage) {
+                this.errorPage = errorPage;
+                return this;
+            }
+
+            public Literal build() {
+                return new Literal(
+                    loginPage,
+                    useForwardToLogin,
+                    useForwardToLoginExpression,
+                    errorPage);
+            }
+
+        }
+
+        public Literal(String loginPage, boolean useForwardToLogin, String useForwardToLoginExpression, String errorPage) {
+            this.loginPage = loginPage;
+            this.useForwardToLogin = useForwardToLogin;
+            this.useForwardToLoginExpression = useForwardToLoginExpression;
+            this.errorPage = errorPage;
+        }
+
+        @Override
+        public String loginPage() {
+            return loginPage;
+        }
+
+        @Override
+        public boolean useForwardToLogin() {
+            return useForwardToLogin;
+        }
+
+        @Override
+        public String useForwardToLoginExpression() {
+            return useForwardToLoginExpression;
+        }
+
+        @Override
+        public String errorPage() {
+            return errorPage;
+        }
+
+    }
+
     /**
      * The resource (page) a caller should get to see in case the originally requested
      * resource requires authentication, and the caller is currently not authenticated.
-     * 
+     *
      * @return page a caller is directed to to authenticate (login)
      */
     @Nonbinding
     String loginPage() default "/login";
-    
+
     /**
-     * Use a forward to reach the page set by the {@link LoginToContinue#loginPage()} 
+     * Use a forward to reach the page set by the {@link LoginToContinue#loginPage()}
      * if true, otherwise use a redirect.
-     * 
+     *
      * @return true if a forward is to be used, false for a redirect
      */
     @Nonbinding
     boolean useForwardToLogin() default true;
-    
+
     /**
      * EL expression variant of <code>useForwardToLogin()</code>.
-     * The expression needs to evaluate to a boolean outcome. All named CDI beans are available 
+     * The expression needs to evaluate to a boolean outcome. All named CDI beans are available
      * to the expression. If both this attribute and <code>useForwardToLogin()</code> are specified, this
      * attribute take precedence.
-     * 
+     *
      * @return an expression evaluating to true if a forward is to be used, false for a redirect
      */
     @Nonbinding
     String useForwardToLoginExpression() default "";
-    
+
     /**
      * The resource (page) a caller should get to see in case an error, such as providing invalid
      * credentials, occurs on the page set by {@link LoginToContinue#loginPage()}.
-     * 
+     *
      * @return page a caller is directed to after an authentication (login) error
      */
     @Nonbinding
     String errorPage() default "/login-error";
-    
+
 }

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/RememberMe.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/RememberMe.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.el.ELProcessor;
+import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -34,26 +36,26 @@ import javax.servlet.http.Cookie;
  * The RememberMe annotation provides an application the ability to declaratively designate
  * that an authentication mechanism effectively "remembers" the authentication and auto
  * applies this with every request.
- * 
+ *
  * <p>
  * For the remember me function the credentials provided by the caller are exchanged for a (long-lived) token
  * which is send to the user as the value of a cookie, in a similar way to how the HTTP session ID is send.
  * It should be realized that this token effectively becomes the credential to establish the caller's
  * identity within the application and care should be taken to handle and store the token securely. E.g.
  * by using this feature with a secure transport (SSL/HTTPS), storing a strong hash instead of the actual
- * token, and implementing an expiration policy. 
- * 
+ * token, and implementing an expiration policy.
+ *
  * <p>
  * The token is vended by a special purpose {@link IdentityStore}-like artifact; an implementation of the
- * {@link RememberMeIdentityStore}.  
- *  
+ * {@link RememberMeIdentityStore}.
+ *
  * <p>
  * This support is provided via an implementation of an interceptor spec interceptor that conducts the
  * necessary logic.
- * 
+ *
  * <p>
  * Example:
- * 
+ *
  * <pre>
  * <code>
  *     {@literal @}RequestScoped
@@ -63,12 +65,12 @@ import javax.servlet.http.Cookie;
  *     }
  * </code>
  * </pre>
- * 
+ *
  * <p>
- * EL expressions in attributes of type <code>String</code> are evaluated for every request requiring 
+ * EL expressions in attributes of type <code>String</code> are evaluated for every request requiring
  * authentication. Both immediate and deferred syntax is supported, but effectively the semantics
  * are always deferred.
- * 
+ *
  * <p>
  * <b>Note:</b> this facility <em>DOES NOT</em> constitute any kind of "session management" system, but instead
  * represents a special purpose authentication mechanism using a long-lived token, that is vended and validated by the
@@ -80,103 +82,270 @@ import javax.servlet.http.Cookie;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface RememberMe {
-    
+
+    /**
+     * A default literal type for the {@link RememberMe} annotation.
+     *
+     * @since 1.1
+     */
+    @SuppressWarnings("all")
+    public final static class Literal extends AnnotationLiteral<RememberMe> implements RememberMe {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int cookieMaxAgeSeconds;
+        private final String cookieMaxAgeSecondsExpression;
+        private final boolean cookieSecureOnly;
+        private final String cookieSecureOnlyExpression;
+        private final boolean cookieHttpOnly;
+        private final String cookieHttpOnlyExpression;
+        private final String cookieName;
+        private final boolean isRememberMe;
+        private final String isRememberMeExpression;
+
+        public static LiteralBuilder of() {
+            return new LiteralBuilder();
+        }
+
+        public static class LiteralBuilder {
+
+            private int cookieMaxAgeSeconds = 86400; // 1 day
+            private String cookieMaxAgeSecondsExpression;
+            private boolean cookieSecureOnly = true;
+            private String cookieSecureOnlyExpression;
+            private boolean cookieHttpOnly = true;
+            private String cookieHttpOnlyExpression;
+            private String cookieName = "JREMEMBERMEID";
+            private boolean isRememberMe = true;
+            private String isRememberMeExpression;
+
+            public LiteralBuilder cookieMaxAgeSeconds(int cookieMaxAgeSeconds) {
+                this.cookieMaxAgeSeconds = cookieMaxAgeSeconds;
+                return this;
+            }
+
+            public LiteralBuilder cookieMaxAgeSecondsExpression (String cookieMaxAgeSecondsExpression) {
+                this.cookieMaxAgeSecondsExpression = cookieMaxAgeSecondsExpression;
+                return this;
+            }
+
+            public LiteralBuilder cookieSecureOnly (boolean cookieSecureOnly) {
+                this.cookieSecureOnly = cookieSecureOnly;
+                return this;
+
+            }
+
+            public LiteralBuilder cookieSecureOnlyExpression (String cookieSecureOnlyExpression) {
+                this.cookieHttpOnlyExpression = cookieSecureOnlyExpression;
+                return this;
+            }
+
+            public LiteralBuilder cookieHttpOnly (boolean cookieHttpOnly) {
+                this.cookieHttpOnly = cookieHttpOnly;
+                return this;
+            }
+
+            public LiteralBuilder cookieHttpOnlyExpression (String cookieHttpOnlyExpression) {
+                this.cookieHttpOnlyExpression = cookieHttpOnlyExpression;
+                return this;
+            }
+
+            public LiteralBuilder cookieName (String cookieName) {
+                this.cookieName = cookieName;
+                return this;
+            }
+
+            public LiteralBuilder isRememberMe (boolean isRememberMe) {
+                this.isRememberMe = isRememberMe;
+                return this;
+            }
+
+            public LiteralBuilder isRememberMeExpression (String isRememberMeExpression) {
+                this.isRememberMeExpression = isRememberMeExpression;
+                return this;
+            }
+
+            public Literal build() {
+                return new Literal(
+                    cookieMaxAgeSeconds,
+                    cookieMaxAgeSecondsExpression,
+                    cookieSecureOnly,
+                    cookieSecureOnlyExpression,
+                    cookieHttpOnly,
+                    cookieHttpOnlyExpression,
+                    cookieName,
+                    isRememberMe,
+                    isRememberMeExpression);
+            }
+        }
+
+        public Literal(
+
+            int cookieMaxAgeSeconds,
+            String cookieMaxAgeSecondsExpression,
+            boolean cookieSecureOnly,
+            String cookieSecureOnlyExpression,
+            boolean cookieHttpOnly,
+            String cookieHttpOnlyExpression,
+            String cookieName,
+            boolean isRememberMe,
+            String isRememberMeExpression
+
+                ) {
+
+            this.cookieMaxAgeSeconds =              cookieMaxAgeSeconds;
+            this.cookieMaxAgeSecondsExpression =    cookieMaxAgeSecondsExpression;
+            this.cookieSecureOnly =                 cookieSecureOnly;
+            this.cookieSecureOnlyExpression =       cookieSecureOnlyExpression;
+            this.cookieHttpOnly =                   cookieHttpOnly;
+            this.cookieHttpOnlyExpression =         cookieHttpOnlyExpression;
+            this.cookieName =                       cookieName;
+            this.isRememberMe =                     isRememberMe;
+            this.isRememberMeExpression =           isRememberMeExpression;
+        }
+
+        @Override
+        public boolean cookieHttpOnly() {
+            return cookieHttpOnly;
+        }
+
+        @Override
+        public String cookieHttpOnlyExpression() {
+            return cookieHttpOnlyExpression;
+        }
+
+        @Override
+        public int cookieMaxAgeSeconds() {
+            return cookieMaxAgeSeconds;
+        }
+
+        @Override
+        public String cookieMaxAgeSecondsExpression() {
+            return cookieMaxAgeSecondsExpression;
+        }
+
+        @Override
+        public boolean cookieSecureOnly() {
+            return cookieSecureOnly;
+        }
+
+        @Override
+        public String cookieSecureOnlyExpression() {
+            return cookieSecureOnlyExpression;
+        }
+
+        @Override
+        public String cookieName() {
+            return cookieName;
+        }
+
+        @Override
+        public boolean isRememberMe() {
+            return isRememberMe;
+        }
+
+        @Override
+        public String isRememberMeExpression() {
+            return isRememberMeExpression;
+        }
+    }
+
     /**
      * Max age in seconds for the remember me cookie.
      * Defaults to one day.
-     * 
+     *
      * @see Cookie#setMaxAge(int)
-     * 
+     *
      * @return Max age in seconds
-     * 
+     *
      */
     @Nonbinding
     int cookieMaxAgeSeconds() default 86400; // 1 day
-    
+
     /**
      * EL expression variant of <code>cookieMaxAgeSeconds()</code>.
      * The expression needs to evaluate to an integer outcome. All named CDI beans are available to the expression
      * as well as default classes as specified by EL 3.0 for the {@link ELProcessor}
      * and the implicit objects "self" which refers to the interceptor target and
-     * "httpMessageContext" which refers to the current {@link HttpMessageContext}. 
+     * "httpMessageContext" which refers to the current {@link HttpMessageContext}.
      * If both this attribute and <code>cookieMaxAgeSeconds()</code> are specified, this
      * attribute takes precedence.
-     * 
+     *
      * @return an expression evaluating to an integer designating the max age in seconds for the remember me cookie.
      */
     @Nonbinding
     String cookieMaxAgeSecondsExpression() default "";
-    
+
     /**
-     * Flag to indicate that the remember me cookie should only be 
+     * Flag to indicate that the remember me cookie should only be
      * sent using a secure protocol (e.g. HTTPS or SSL).
-     * 
+     *
      * @see Cookie#setSecure(boolean)
-     * 
+     *
      * @return true if the cookie should be sent using a secure protocol only
      * false for any protocol.
      */
     @Nonbinding
     boolean cookieSecureOnly() default true;
-    
+
     /**
      * EL expression variant of <code>cookieSecureOnly()</code>.
      * The expression needs to evaluate to a boolean outcome. All named CDI beans are available to the expression
      * as well as default classes as specified by EL 3.0 for the {@link ELProcessor}
      * and the implicit objects "self" which refers to the interceptor target and
-     * "httpMessageContext" which refers to the current {@link HttpMessageContext}. 
+     * "httpMessageContext" which refers to the current {@link HttpMessageContext}.
      * If both this attribute and <code>cookieSecureOnly()</code> are specified, this
      * attribute takes precedence.
-     * 
+     *
      * @return an expression evaluating to an integer designating the max age in seconds for the remember me cookie.
      */
     @Nonbinding
     String cookieSecureOnlyExpression() default "";
-    
+
     /**
      * Flag to indicate that the remember me cookie should not be exposed to
      * client-side scripting code, and should only be sent with HTTP requests.
-     * 
+     *
      * @see Cookie#setHttpOnly(boolean)
-     * 
-     * @return true if the cookie should be sent only with HTTP requests 
+     *
+     * @return true if the cookie should be sent only with HTTP requests
      * (and not be made available to client-side scripting code), false otherwise.
      */
     @Nonbinding
     boolean cookieHttpOnly() default true;
-    
+
     /**
      * EL expression variant of <code>cookieHttpOnly()</code>.
      * The expression needs to evaluate to a boolean outcome. All named CDI beans are available to the expression
      * as well as default classes as specified by EL 3.0 for the {@link ELProcessor}
      * and the implicit objects "self" which refers to the interceptor target and
-     * "httpMessageContext" which refers to the current {@link HttpMessageContext}. 
+     * "httpMessageContext" which refers to the current {@link HttpMessageContext}.
      * If both this attribute and <code>cookieHttpOnly()</code> are specified, this
      * attribute takes precedence.
-     * 
+     *
      * @return an expression evaluating to true if the cookie should be sent only with HTTP requests , false otherwise.
      */
     @Nonbinding
     String cookieHttpOnlyExpression() default "";
-    
+
     /**
      * Name of the remember me cookie.
-     * 
+     *
      * @see Cookie#getName()
-     * 
+     *
      * @return The name of the cookie
      */
     @Nonbinding
     String cookieName() default "JREMEMBERMEID";
-    
+
     /**
      * Flag to determine if remember me should be used.
-     * 
+     *
      * @return Flag to determine if remember me should be used
      */
     @Nonbinding
     boolean isRememberMe() default true;
-    
+
     /**
      * EL expression to determine if remember me should be used. This is evaluated
      * for every request requiring authentication. The expression needs to evaluate
@@ -184,9 +353,9 @@ public @interface RememberMe {
      * as well as default classes as specified by EL 3.0 for the {@link ELProcessor}
      * and the implicit objects "self" which refers to the interceptor target and
      * "httpMessageContext" which refers to the current {@link HttpMessageContext}.
-     * 
+     *
      * @return EL expression to determine if remember me should be used
-     * 
+     *
      */
     @Nonbinding
     String isRememberMeExpression() default "";

--- a/src/test/java/org/glassfish/security/AnnotationLiteralTest.java
+++ b/src/test/java/org/glassfish/security/AnnotationLiteralTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018 Payara Services and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.security;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+
+import org.junit.Test;
+
+public class AnnotationLiteralTest {
+
+
+    @Test
+    public void testAutoApplySession() {
+        AutoApplySession literal = AutoApplySession.Literal.INSTANCE;
+
+        assertEquals(new AnnotationLiteral<AutoApplySession>() {
+            private static final long serialVersionUID = 1L;
+        },  literal);
+
+    }
+
+    @Test
+    public void testRememberMeDefault() {
+        RememberMe literal = RememberMe.Literal.of().build();
+
+        assertEquals(86400, literal.cookieMaxAgeSeconds());
+        assertEquals("JREMEMBERMEID", literal.cookieName());
+    }
+
+    @Test
+    public void testRememberMe() {
+        RememberMe literal = RememberMe.Literal.of()
+                                       .cookieMaxAgeSeconds(100)
+                                       .cookieSecureOnly(false)
+                                       .cookieHttpOnly(false)
+                                       .build();
+
+        assertEquals(100, literal.cookieMaxAgeSeconds());
+        assertEquals(false, literal.cookieSecureOnly());
+        assertEquals(false, literal.cookieHttpOnly());
+        assertEquals("JREMEMBERMEID", literal.cookieName());
+    }
+
+    @Test
+    public void testLoginToContinueDefault() {
+        LoginToContinue literal = LoginToContinue.Literal.of().build();
+
+        assertEquals("/login", literal.loginPage());
+        assertEquals("/login-error", literal.errorPage());
+    }
+
+    @Test
+    public void testLoginToContinue() {
+        LoginToContinue literal = LoginToContinue.Literal.of()
+                                                 .loginPage("/mylogin")
+                                                 .useForwardToLogin(false)
+                                                 .useForwardToLoginExpression("#{bar.foo}")
+                                                 .build();
+
+        assertEquals("/mylogin", literal.loginPage());
+        assertEquals(false, literal.useForwardToLogin());
+        assertEquals("#{bar.foo}", literal.useForwardToLoginExpression());
+        assertEquals("/login-error", literal.errorPage());
+    }
+
+
+
+
+}


### PR DESCRIPTION
PR for #82 Add annotation literals for built-in annotations.

The following annotations made sense to have literals for them:

* AutoApplySession
* LoginToContinue
* RememberMe

There are the interceptor binding annotations. The *Definition annotations are just plain (no CDI) annotations and don't need literals. We don't have qualifiers in EE Security (yet).
