### PR TITLE
Automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,19 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <!-- Provide a stable automatic module name so other artifacts can depend on project -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>java.security.enterprise</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <!-- Configure the jar with the sources (or rather, convince Maven that
             we want sources at all) -->
             <plugin>


### PR DESCRIPTION
This is a first step before true modularization. We still depend on some projects which don't provide module names so I don't think we can go further right now.