### PR TITLE
 Replace dependency for javaee-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </properties>
 
     <licenses>
-      <license>
+        <license>
             <name>EPL 2.0</name>
             <url>http://www.eclipse.org/legal/epl-2.0</url>
             <distribution>repo</distribution>
@@ -76,15 +76,58 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.0</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.interceptor</groupId>
+            <artifactId>javax.interceptor-api</artifactId>
+            <version>1.2.1</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>3.0.1-b04</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>javax.ejb-api</artifactId>
+            <version>3.2</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.security.auth.message</groupId>
+            <artifactId>javax.security.auth.message-api</artifactId>
+            <version>1.1</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.security.jacc</groupId>
+            <artifactId>javax.security.jacc-api</artifactId>
+            <version>1.5</version>
+             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -78,49 +78,49 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>
             <artifactId>javax.interceptor-api</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>3.0.1-b04</version>
+            <version>3.0.1-b06</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.ejb</groupId>
             <artifactId>javax.ejb-api</artifactId>
-            <version>3.2</version>
+            <version>3.2.2</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
+            <version>2.0.SP1</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.security.auth.message</groupId>
             <artifactId>javax.security.auth.message-api</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.security.jacc</groupId>
             <artifactId>javax.security.jacc-api</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
              <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Hi,

@keilw this is a reworking of PR #87.

1st commit replaces with actual dependencies from `javaee-api` (transitively `javaee-web-api`)
2nd commit updates to latest versions available in Maven central.

I didn't replace the equivalents available from EE4J, because it would require adding a snapshot repository, which I couldn't find (ref: [EE4J #27](https://github.com/eclipse-ee4j/ee4j/issues/27) and [ee4j-pmc](https://www.eclipse.org/lists/ee4j-pmc/msg00653.html))


| Previous | In javax:javaee-api:8.0 | In Maven Central | EE4J Equivalent |
| -------- | ----------------------- | --------------- | --------------- |
| javax.servlet:javax.servlet-api:3.1.0       | 4.0.0 | 4.0.1 | jakarta.servlet:jakarta.servlet-api:4.0.2-SNAPSHOT |
| javax.interceptor:javax.interceptor-api:1.2 | 1.2.1 | 1.2.2 | jakarta.interceptor:jakarta.interceptor-api:1.2.3-SNAPSHOT |
| javax.el:javax.el-api:3.0.0                 | 3.0.1-b04 | 3.0.1-b06 | |
| javax.ejb:javax.ejb-api:3.2                 | 3.2 | 3.2.2   | jakarta.ejb:jakarta.ejb-api:3.2.3-SNAPSHOT |
| javax.enterprise:cdi-api:1.1                | 2.0 | 2.0.SP1 | |
| javax.security.auth.message:javax.security.auth.message-api:1.1 | 1.1 | 1.1.1 | |
| javax.security.jacc:javax.security.jacc-api:1.5 | 1.5 | 1.6 | |
| junit:junit:4.11                            | n/a | 4.12 | n/a |

As @ggam [previously stated](https://github.com/eclipse-ee4j/security-api/pull/87#issuecomment-405991130) a maven BOM would be great, and I'd guess widely consumed e.g. microprofile.