### PR TITLE
Add extra tests for REST roles allowed

### DIFF
--- a/tck/app-rest-rolesallowed-overlap/pom.xml
+++ b/tck/app-rest-rolesallowed-overlap/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.security.tck</groupId>
+        <artifactId>jakarta-security-tck</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>app-rest-rolesallowed-overlap</artifactId>
+    <packaging>war</packaging>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.security.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>4.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        
+    </dependencies>
+
+    <build>
+        <finalName>app-rest-rolesallowed-overlap</finalName>
+    </build>
+</project>

--- a/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/ProtectedTemplateResource.java
+++ b/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/ProtectedTemplateResource.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+
+// The template pattern matches exactly that of PublicTemplateResource
+// with just the regexp different, but matching our rest input "Reza".
+// It's not defined which one is chosen, but we do specify the
+// security system before the (servlet) chain is invoked and the
+// actual invocation of the resource must be consistent
+@Path("/protectedResource/{id}/users/{username: [A-Z][a-zA-Z_0-9]*}")
+@Produces(TEXT_PLAIN)
+@RolesAllowed("foo")
+public class ProtectedTemplateResource {
+
+    @Inject
+    private HttpServletRequest request;
+
+    @GET
+    @Path("sayHi")
+    public String sayHi() {
+       return "saying hi! protected should be true, protected=" + request.getAttribute("PROTECTED");
+    }
+
+}

--- a/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/PublicTemplateResource.java
+++ b/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/PublicTemplateResource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+
+// The template pattern matches exactly that of ProtectedTemplateResource
+// with just the regexp different, but matching our rest input "Reza".
+// It's not defined which one is chosen, but we do specify the
+// security system before the (servlet) chain is invoked and the
+// actual invocation of the resource must be consistent
+@Path("/protectedResource/{id}/users/{username: [a-zA-Z_0-9]*}")
+@Produces(TEXT_PLAIN)
+public class PublicTemplateResource {
+
+    @Inject
+    private HttpServletRequest request;
+
+    @GET
+    @Path("sayHi")
+    public String sayHi() {
+       return "saying hi! protected should be false, protected=" + request.getAttribute("PROTECTED");
+    }
+
+}

--- a/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/RestActivator.java
+++ b/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/RestActivator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+@DeclareRoles({ "foo", "bar", "kaz" })
+public class RestActivator extends Application {
+  
+}

--- a/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/TestAuthenticationMechanism.java
+++ b/tck/app-rest-rolesallowed-overlap/src/main/java/ee/jakarta/tck/security/test/TestAuthenticationMechanism.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import static java.util.Arrays.asList;
+import static ee.jakarta.tck.security.test.Utils.notNull;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+
+import java.util.HashSet;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ApplicationScoped
+public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException {
+        request.setAttribute("PROTECTED", httpMessageContext.isProtected()? "true" : "false");
+
+        // The request attribute can only be observed via the response body of the resource that is
+        // invoked. The same value is set as a response header as well, so it can be observed for
+        // requests where no resource is invoked, and for requests that have no response body at all,
+        // such as HEAD requests.
+        response.setHeader("X-Protected", httpMessageContext.isProtected()? "true" : "false");
+
+        String name = request.getParameter("name");
+        String password = request.getParameter("password");
+
+        if (notNull(name, password)) {
+            return httpMessageContext.notifyContainerAboutLogin(
+                validate(
+                    new UsernamePasswordCredential(name, password)));
+
+        }
+
+        return httpMessageContext.doNothing();
+    }
+
+    public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
+
+        if (usernamePasswordCredential.compareTo("reza", "secret1")) {
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
+        }
+
+        return INVALID_RESULT;
+    }
+
+}

--- a/tck/app-rest-rolesallowed-overlap/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/app-rest-rolesallowed-overlap/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="4.0">
+</beans>

--- a/tck/app-rest-rolesallowed-overlap/src/test/java/ee/jakarta/tck/security/test/AppRestRolesAllowedTemplateIT.java
+++ b/tck/app-rest-rolesallowed-overlap/src/test/java/ee/jakarta/tck/security/test/AppRestRolesAllowedTemplateIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import static ee.jakarta.tck.security.test.ShrinkWrap.mavenWar;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for REST template resources of which the templates overlap; both the protected and the
+ * public resource match the request path used here. Which one is selected is not defined, so these
+ * tests do not assert which resource is invoked, but assert that the security system and the actual
+ * invocation are consistent with each other.
+ */
+@RunWith(Arquillian.class)
+public class AppRestRolesAllowedTemplateIT extends ArquillianBase {
+
+    private static final String OVERLAPPING_PATH = "/rest/protectedResource/21/users/Reza/sayHi";
+    private static final String CREDENTIALS = "?name=reza&password=secret1";
+
+    @ArquillianResource
+    private URL base;
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        try {
+            return mavenWar();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    @Test
+    public void testSayHi() {
+        String response = readFromServer(OVERLAPPING_PATH + CREDENTIALS);
+
+        assertTrue(
+            "Endpoint should have been called, but was not",
+            response.contains("saying hi!"));
+
+        // Test whether what the authentication mechanism saw and what is actually invoked as resource is
+        // consistent
+        assertTrue(
+            "Either public or protected resource may be called, but has to be consistent with what authentication mechanism sees.",
+            response.contains("protected should be true, protected=true") ||
+            response.contains("protected should be false, protected=false"));
+    }
+
+    /**
+     * Without credentials the outcome depends on which of the two overlapping templates is selected;
+     * the protected one denies the request, the public one serves it. Either is allowed, as long as
+     * the authentication mechanism saw the same thing.
+     */
+    @Test
+    public void testSayHiNotAuthenticated() {
+        WebResponse response = responseFromServer(OVERLAPPING_PATH);
+        String content = response.getContentAsString();
+        String protectedHeader = response.getResponseHeaderValue("X-Protected");
+
+        assertNotNull(
+            "Authentication mechanism should have run for the request, but did not",
+            protectedHeader);
+
+        assertTrue(
+            "Either public or protected resource may be selected, but the outcome has to be consistent "
+                + "with what the authentication mechanism sees.",
+            ("true".equals(protectedHeader) && !content.contains("saying hi!")) ||
+            ("false".equals(protectedHeader) && content.contains("protected should be false, protected=false")));
+    }
+
+    /**
+     * A HEAD request is served by the GET resource method when no explicit HEAD method is declared,
+     * so it selects the very same resource as the GET request does. The security system therefore
+     * has to see a HEAD request exactly like it sees the GET request; a HEAD request must not be
+     * treated as unconstrained just because no HEAD endpoint exists.
+     *
+     * <p>
+     * This holds no matter which of the two overlapping templates is selected, which is why the GET
+     * outcome is used as the expected value rather than a fixed one.
+     */
+    @Test
+    public void testHeadIsSeenTheSameAsGet() {
+        WebResponse getResponse = responseFromServer(OVERLAPPING_PATH + CREDENTIALS);
+        WebResponse headResponse = headResponseFromServer(OVERLAPPING_PATH + CREDENTIALS);
+
+        assertNotNull(
+            "Authentication mechanism should have run for the GET request, but did not",
+            getResponse.getResponseHeaderValue("X-Protected"));
+
+        assertEquals(
+            "A HEAD request is served by the GET resource method, so the authentication mechanism has to "
+                + "see it the same way as it sees the GET request",
+            getResponse.getResponseHeaderValue("X-Protected"),
+            headResponse.getResponseHeaderValue("X-Protected"));
+    }
+
+    @Test
+    public void testHeadIsSeenTheSameAsGetNotAuthenticated() {
+        WebResponse getResponse = responseFromServer(OVERLAPPING_PATH);
+        WebResponse headResponse = headResponseFromServer(OVERLAPPING_PATH);
+
+        assertNotNull(
+            "Authentication mechanism should have run for the GET request, but did not",
+            getResponse.getResponseHeaderValue("X-Protected"));
+
+        assertEquals(
+            "A HEAD request is served by the GET resource method, so the authentication mechanism has to "
+                + "see it the same way as it sees the GET request",
+            getResponse.getResponseHeaderValue("X-Protected"),
+            headResponse.getResponseHeaderValue("X-Protected"));
+
+        assertEquals(
+            "A HEAD request has to be authorized the same way as the GET request",
+            getResponse.getStatusCode(),
+            headResponse.getStatusCode());
+    }
+
+
+    // ### Private methods
+
+
+    /**
+     * Performs a HEAD request. {@link ArquillianBase#responseFromServer(String)} always does a GET,
+     * and a HEAD request has to be exercised separately because it is served by the GET resource
+     * method without such a method being declared.
+     *
+     * @param path The context relative path to request, for example {@code /rest/foo}.
+     */
+    private WebResponse headResponseFromServer(String path) {
+        String requestPath = path;
+        if (base.toString().endsWith("/") && requestPath.startsWith("/")) {
+            requestPath = requestPath.substring(1);
+        }
+
+        try {
+            return getWebClient().loadWebResponse(
+                new WebRequest(URI.create(base + requestPath).toURL(), HttpMethod.HEAD));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/tck/app-rest-rolesallowed/src/test/java/ee/jakarta/tck/security/test/AppRestRolesAllowedTemplateIT.java
+++ b/tck/app-rest-rolesallowed/src/test/java/ee/jakarta/tck/security/test/AppRestRolesAllowedTemplateIT.java
@@ -16,21 +16,36 @@
 
 package ee.jakarta.tck.security.test;
 
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 
 import static ee.jakarta.tck.security.test.ShrinkWrap.mavenWar;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-
+/**
+ * Tests for REST template resources of which the templates do not overlap; the protected resource
+ * matches an upper case first character of the user name, the public one a lower case first
+ * character. Every request therefore selects a single, known resource, and the tests can assert
+ * the exact outcome.
+ */
 @RunWith(Arquillian.class)
 public class AppRestRolesAllowedTemplateIT extends ArquillianBase {
+
+    @ArquillianResource
+    private URL base;
 
     @Deployment(testable = false)
     public static Archive<?> createDeployment() {
@@ -105,6 +120,135 @@ public class AppRestRolesAllowedTemplateIT extends ArquillianBase {
         assertTrue(
             "Authentication mechanism should have seen the REST template resource as public",
             response.contains("protected=false"));
+    }
+
+    /**
+     * A HEAD request is served by the GET resource method when no explicit HEAD method is declared.
+     * The security system therefore has to see the constraint of that GET method, and must not
+     * conclude that no constraint applies just because no HEAD endpoint exists.
+     */
+    @Test
+    public void testHeadNotAuthenticated() {
+        WebResponse response = headResponseFromServer("/rest/protectedResource/21/users/Reza/sayHi");
+
+        assertEquals(
+            "Authentication mechanism should have seen the HEAD request for the REST template resource as protected",
+            "true",
+            response.getResponseHeaderValue("X-Protected"));
+    }
+
+    /**
+     * The counterpart of the above; the HEAD request for an authenticated and authorized caller has
+     * to be allowed through, and has to be seen as protected as well.
+     */
+    @Test
+    public void testHeadAuthenticated() {
+        WebResponse response = headResponseFromServer("/rest/protectedResource/21/users/Reza/sayHi?name=reza&password=secret1");
+
+        assertEquals(
+            "HEAD request should have been allowed, but was not",
+            200,
+            response.getStatusCode());
+
+        assertEquals(
+            "Authentication mechanism should have seen the HEAD request for the REST template resource as protected",
+            "true",
+            response.getResponseHeaderValue("X-Protected"));
+    }
+
+    /**
+     * A HEAD request for the lower case template selects the public resource, which has no
+     * constraint at all.
+     */
+    @Test
+    public void testHeadLowercaseTemplatePathHitsPublicResource() {
+        WebResponse response = headResponseFromServer("/rest/protectedResource/21/users/reza/sayHi");
+
+        assertEquals(
+            "Authentication mechanism should have seen the HEAD request for the REST template resource as public",
+            "false",
+            response.getResponseHeaderValue("X-Protected"));
+    }
+
+    @Test
+    public void testCallerName() {
+        String response = readFromServer("/rest/protectedResource/21/users/Reza/callerName?name=reza&password=secret1");
+
+        assertTrue(
+            "Should be authenticated as user reza but was not",
+            response.contains("reza"));
+    }
+
+    @Test
+    public void testNotCallerNameNotAuthenticated() {
+        WebResponse response = responseFromServer("/rest/protectedResource/21/users/Reza/callerName");
+
+        assertFalse(
+            "Endpoint should not have been called, but was",
+            response.getContentAsString().contains("reza"));
+
+        assertEquals(
+            "Authentication mechanism should have seen the REST template resource as protected",
+            "true",
+            response.getResponseHeaderValue("X-Protected"));
+    }
+
+    @Test
+    public void testHasRoleFoo() {
+        String response = readFromServer("/rest/protectedResource/21/users/Reza/hasRoleFoo?name=reza&password=secret1");
+
+        assertTrue(
+            "Should be in role foo, but was not",
+            response.contains("true"));
+    }
+
+    @Test
+    public void testNotHasRoleKaz() {
+        // The class level constraint is role "foo", which reza has, so the endpoint is called.
+        // Reza is not in role "kaz" though.
+        String response = readFromServer("/rest/protectedResource/21/users/Reza/hasRoleKaz?name=reza&password=secret1");
+
+        assertFalse(
+            "Should not be in role kaz, but was",
+            response.contains("true"));
+    }
+
+    /**
+     * The public template resource has no constraints at all, so an unauthenticated caller reaches
+     * the endpoint and simply has no caller principal.
+     */
+    @Test
+    public void testLowercaseTemplateCallerNameNotAuthenticated() {
+        String response = readFromServer("/rest/protectedResource/21/users/reza/callerName");
+
+        assertFalse(
+            "Should not be authenticated as user reza but was",
+            response.contains("reza"));
+    }
+
+
+    // ### Private methods
+
+
+    /**
+     * Performs a HEAD request. {@link ArquillianBase#responseFromServer(String)} always does a GET,
+     * and a HEAD request has to be exercised separately because it is served by the GET resource
+     * method without such a method being declared.
+     *
+     * @param path The context relative path to request, for example {@code /rest/foo}.
+     */
+    private WebResponse headResponseFromServer(String path) {
+        String requestPath = path;
+        if (base.toString().endsWith("/") && requestPath.startsWith("/")) {
+            requestPath = requestPath.substring(1);
+        }
+
+        try {
+            return getWebClient().loadWebResponse(
+                new WebRequest(URI.create(base + requestPath).toURL(), HttpMethod.HEAD));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
 }

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.5</version>
         <relativePath/>
     </parent>
 
@@ -51,6 +51,7 @@
         <module>common</module>
         
         <module>app-rest-rolesallowed</module>
+        <module>app-rest-rolesallowed-overlap</module>
 
         <module>app-securitycontext</module>
         <module>app-securitycontext-auth</module>


### PR DESCRIPTION
This adds coverage of REST template patterns, and specifically template patterns that overlap without a spec defined resolution.